### PR TITLE
[API_6378] [Finstore] relatives sur la transaction

### DIFF
--- a/src/main/scala/com/particeep/api/models/transaction/Transaction.scala
+++ b/src/main/scala/com/particeep/api/models/transaction/Transaction.scala
@@ -9,25 +9,26 @@ import com.particeep.api.models.enums.TransactionStatus.{ PENDING, TransactionSt
 import play.api.libs.json.{ JsObject, Json }
 
 case class Transaction(
-  id:              String                = "",
-  created_at:      Option[ZonedDateTime] = None,
-  issuer_id:       String                = "",
-  issuer_type:     String                = "",
-  recipient_id:    String                = "",
-  recipient_type:  String                = "",
-  fundraise_id:    Option[String]        = None,
-  fundraise_type:  Option[String]        = None,
-  item_id:         Option[String]        = None,
-  item_type:       Option[String]        = None,
-  amount:          Int                   = 0,
-  fees:            Int                   = 0,
-  currency:        Currency              = EUR,
-  status:          TransactionStatus     = PENDING,
-  payment_method:  Option[PaymentMethod] = None,
-  handled_offline: Option[Boolean]       = None,
-  comment:         Option[String]        = None,
-  tag:             Option[String]        = None,
-  custom:          Option[JsObject]      = None
+  id:               String                = "",
+  created_at:       Option[ZonedDateTime] = None,
+  issuer_id:        String                = "",
+  issuer_type:      String                = "",
+  recipient_id:     String                = "",
+  recipient_type:   String                = "",
+  fundraise_id:     Option[String]        = None,
+  fundraise_type:   Option[String]        = None,
+  item_id:          Option[String]        = None,
+  item_type:        Option[String]        = None,
+  amount:           Int                   = 0,
+  fees:             Int                   = 0,
+  currency:         Currency              = EUR,
+  status:           TransactionStatus     = PENDING,
+  payment_method:   Option[PaymentMethod] = None,
+  handled_offline:  Option[Boolean]       = None,
+  comment:          Option[String]        = None,
+  tag:              Option[String]        = None,
+  issuer_relatives: Option[JsObject]      = None,
+  custom:           Option[JsObject]      = None
 )
 
 object Transaction {

--- a/src/main/scala/com/particeep/api/models/transaction/TransactionCreation.scala
+++ b/src/main/scala/com/particeep/api/models/transaction/TransactionCreation.scala
@@ -10,21 +10,22 @@ import play.api.libs.json.{ JsObject, Json }
  * Created by Noe on 03/04/2017.
  */
 case class TransactionCreation(
-  created_at:     Option[ZonedDateTime] = None,
-  issuer_id:      String                = "",
-  issuer_type:    String                = "",
-  recipient_id:   String                = "",
-  recipient_type: String                = "",
-  fundraise_id:   Option[String]        = None,
-  fundraise_type: Option[String]        = None,
-  item_id:        Option[String]        = None,
-  item_type:      Option[String]        = None,
-  amount:         Int                   = 0,
-  fees:           Int                   = 0,
-  currency:       Currency              = EUR,
-  comment:        Option[String]        = None,
-  tag:            Option[String]        = None,
-  custom:         Option[JsObject]      = None
+  created_at:       Option[ZonedDateTime] = None,
+  issuer_id:        String                = "",
+  issuer_type:      String                = "",
+  recipient_id:     String                = "",
+  recipient_type:   String                = "",
+  fundraise_id:     Option[String]        = None,
+  fundraise_type:   Option[String]        = None,
+  item_id:          Option[String]        = None,
+  item_type:        Option[String]        = None,
+  amount:           Int                   = 0,
+  fees:             Int                   = 0,
+  currency:         Currency              = EUR,
+  comment:          Option[String]        = None,
+  tag:              Option[String]        = None,
+  issuer_relatives: Option[JsObject]      = None,
+  custom:           Option[JsObject]      = None
 )
 
 object TransactionCreation {

--- a/src/main/scala/com/particeep/api/models/transaction/TransactionData.scala
+++ b/src/main/scala/com/particeep/api/models/transaction/TransactionData.scala
@@ -36,6 +36,7 @@ case class TransactionData(
   partner_flat_fees:     Option[Int]           = None,
   partner_variable_fees: Option[Double]        = None,
   tag:                   Option[String]        = None,
+  issuer_relatives:      Option[JsObject]      = None,
   custom:                Option[JsObject]      = None
 )
 

--- a/src/main/scala/com/particeep/api/models/transaction/TransactionEdition.scala
+++ b/src/main/scala/com/particeep/api/models/transaction/TransactionEdition.scala
@@ -7,21 +7,22 @@ import play.api.libs.json.{ JsObject, Json }
  * Created by Noe on 25/04/2017.
  */
 case class TransactionEdition(
-  issuer_id:       Option[String]   = None,
-  issuer_type:     Option[String]   = None,
-  recipient_id:    Option[String]   = None,
-  recipient_type:  Option[String]   = None,
-  fundraise_id:    Option[String]   = None,
-  fundraise_type:  Option[String]   = None,
-  item_id:         Option[String]   = None,
-  item_type:       Option[String]   = None,
-  amount:          Option[Int]      = None,
-  fees:            Option[Int]      = None,
-  currency:        Option[Currency] = None,
-  handled_offline: Option[Boolean]  = None,
-  comment:         Option[String]   = None,
-  tag:             Option[String]   = None,
-  custom:          Option[JsObject] = None
+  issuer_id:        Option[String]   = None,
+  issuer_type:      Option[String]   = None,
+  recipient_id:     Option[String]   = None,
+  recipient_type:   Option[String]   = None,
+  fundraise_id:     Option[String]   = None,
+  fundraise_type:   Option[String]   = None,
+  item_id:          Option[String]   = None,
+  item_type:        Option[String]   = None,
+  amount:           Option[Int]      = None,
+  fees:             Option[Int]      = None,
+  currency:         Option[Currency] = None,
+  handled_offline:  Option[Boolean]  = None,
+  comment:          Option[String]   = None,
+  tag:              Option[String]   = None,
+  issuer_relatives: Option[JsObject] = None,
+  custom:           Option[JsObject] = None
 )
 
 object TransactionEdition {


### PR DESCRIPTION
rajouter le champ issuer_relatives: JsObject sur transaction qui permettra de stocker les infos des relatives du user