### PR TITLE
[SDK_6597 ] changer la gestion du champs iban

### DIFF
--- a/src/main/scala/com/particeep/api/models/fundraise/equity/InvestmentCreation.scala
+++ b/src/main/scala/com/particeep/api/models/fundraise/equity/InvestmentCreation.scala
@@ -3,14 +3,14 @@ package com.particeep.api.models.fundraise.equity
 import java.time.ZonedDateTime
 
 import com.particeep.api.core.Formatter
-import play.api.libs.json.{ JsArray, Json }
+import play.api.libs.json.{ JsArray, JsObject, Json }
 
 case class InvestmentCreation(
   user_id:    String,
   amount:     Int,
-  rib:        Option[String]        = None,
   co_issuers: Option[JsArray]       = None,
-  created_at: Option[ZonedDateTime]
+  created_at: Option[ZonedDateTime],
+  custom:     Option[JsObject]      = None
 )
 
 object InvestmentCreation {

--- a/src/main/scala/com/particeep/api/models/fundraise/loan/LendCreation.scala
+++ b/src/main/scala/com/particeep/api/models/fundraise/loan/LendCreation.scala
@@ -3,14 +3,14 @@ package com.particeep.api.models.fundraise.loan
 import java.time.ZonedDateTime
 
 import com.particeep.api.core.Formatter
-import play.api.libs.json.{ JsArray, Json }
+import play.api.libs.json.{ JsArray, JsObject, Json }
 
 case class LendCreation(
   user_id:    String,
   amount:     Int,
-  rib:        Option[String]        = None,
   co_issuers: Option[JsArray]       = None,
-  created_at: Option[ZonedDateTime]
+  created_at: Option[ZonedDateTime],
+  custom:     Option[JsObject]      = None
 )
 
 object LendCreation {


### PR DESCRIPTION
conserver un JsObject bank_account_info dans le champ custom transaction au lieu de rib string dans la commentaire