### PR TITLE
Utiliser la dénomination sociale dans les critères de recherche

### DIFF
--- a/src/main/scala/com/particeep/api/models/user/UserData.scala
+++ b/src/main/scala/com/particeep/api/models/user/UserData.scala
@@ -57,7 +57,13 @@ case class UserData(
     relatives:                     Option[Seq[Relative]]    = None,
     bankaccounts:                  Option[Seq[BankAccount]] = None,
     custom:                        Option[JsObject]         = None,
-    company_business_name:         Option[String]           = None
+    company_business_name:         Option[String]           = None,
+    siren:                         Option[String]           = None,
+    siret:                         Option[String]           = None,
+    rcs_registration_year:         Option[String]           = None,
+    rcs_city:                      Option[String]           = None,
+    legal_status:                  Option[String]           = None,
+    tva_intra:                     Option[String]           = None
 )
 
 object UserData {

--- a/src/main/scala/com/particeep/api/models/user/UserData.scala
+++ b/src/main/scala/com/particeep/api/models/user/UserData.scala
@@ -56,7 +56,8 @@ case class UserData(
     lang:                          Option[String]           = None,
     relatives:                     Option[Seq[Relative]]    = None,
     bankaccounts:                  Option[Seq[BankAccount]] = None,
-    custom:                        Option[JsObject]         = None
+    custom:                        Option[JsObject]         = None,
+    company_business_name:         Option[String]           = None
 )
 
 object UserData {

--- a/src/main/scala/com/particeep/api/models/user/UserSearch.scala
+++ b/src/main/scala/com/particeep/api/models/user/UserSearch.scala
@@ -30,5 +30,11 @@ case class UserSearch(
 case class UserSearchAdditional(
     account_validation_status: Option[String] = None,
     partner_manager_id:        Option[String] = None,
-    company_business_name:     Option[String] = None
+    company_business_name:     Option[String] = None,
+    siren:                     Option[String] = None,
+    siret:                     Option[String] = None,
+    rcs_registration_year:     Option[String] = None,
+    rcs_city:                  Option[String] = None,
+    legal_status:              Option[String] = None,
+    tva_intra:                 Option[String] = None
 )

--- a/src/main/scala/com/particeep/api/models/user/UserSearch.scala
+++ b/src/main/scala/com/particeep/api/models/user/UserSearch.scala
@@ -29,5 +29,6 @@ case class UserSearch(
 
 case class UserSearchAdditional(
     account_validation_status: Option[String] = None,
-    partner_manager_id:        Option[String] = None
+    partner_manager_id:        Option[String] = None,
+    company_business_name:     Option[String] = None
 )


### PR DESCRIPTION
Bonjour,

Le but de cette PR est d'ajouter le champ "company_business_name" afin de permettre une recherche sur ce critère sur la page investisseur.