### PR TITLE
Refacto du code sur la gestion d'un patrimoine.

### DIFF
--- a/src/main/scala/com/particeep/api/models/user/UserPatrimony.scala
+++ b/src/main/scala/com/particeep/api/models/user/UserPatrimony.scala
@@ -4,10 +4,10 @@ import ai.x.play.json.Encoders._
 import ai.x.play.json.Jsonx
 
 case class UserPatrimony(
-    yearly_income:     Option[Long],
-    total_liquidity:   Option[Long],
-    yearly_engagement: Option[Long],
-    exploit_result:    Option[Long]
+    yearly_income:     Long = 0L,
+    total_liquidity:   Long = 0L,
+    yearly_engagement: Long = 0L,
+    exploit_result:    Long = 0L
 )
 
 object UserPatrimony {


### PR DESCRIPTION
Pour harmoniser ce qu'il dans nos serveurs, les champs d'UserPatrimony sont maintenant obligatoires si le champ patrimony est renseigné.