### PR TITLE
 Récupérer le document à télécharger

### DIFF
--- a/src/main/scala/com/particeep/api/DocumentClient.scala
+++ b/src/main/scala/com/particeep/api/DocumentClient.scala
@@ -7,7 +7,6 @@ import com.particeep.api.models.document._
 import com.particeep.api.models.{ ErrorResult, PaginatedSequence, TableSearch }
 import com.particeep.api.utils.LangUtils
 import play.api.libs.json.Json
-import play.api.mvc.Result
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -57,8 +56,8 @@ class DocumentClient(val ws: WSClient, val credentials: Option[ApiCredential] = 
     ws.post[Document](s"$endPoint/$owner_id/dir", timeout, Json.toJson(document_creation))
   }
 
-  def download(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, Result]] = {
-    ws.getDoc(path = s"$endPoint/download/$id", timeOut = timeout)
+  def download(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, DocumentDownload]] = {
+    ws.getDoc(document_id = id, path = s"$endPoint/download/$id", timeOut = timeout)
   }
 
   def byId(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, Document]] = {

--- a/src/main/scala/com/particeep/api/DocumentClient.scala
+++ b/src/main/scala/com/particeep/api/DocumentClient.scala
@@ -1,16 +1,13 @@
 package com.particeep.api
 
 import java.io.File
-
 import play.shaded.ahc.org.asynchttpclient.request.body.multipart.StringPart
 import com.particeep.api.core._
 import com.particeep.api.models.document._
 import com.particeep.api.models.{ ErrorResult, PaginatedSequence, TableSearch }
 import com.particeep.api.utils.LangUtils
-import akka.NotUsed
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
 import play.api.libs.json.Json
+import play.api.mvc.Result
 
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -60,8 +57,8 @@ class DocumentClient(val ws: WSClient, val credentials: Option[ApiCredential] = 
     ws.post[Document](s"$endPoint/$owner_id/dir", timeout, Json.toJson(document_creation))
   }
 
-  def download(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, Source[ByteString, NotUsed]]] = {
-    ws.getStream(s"$endPoint/download/$id", timeout)
+  def download(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, Result]] = {
+    ws.getDoc(path = s"$endPoint/download/$id", timeOut = timeout)
   }
 
   def byId(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, Document]] = {

--- a/src/main/scala/com/particeep/api/core/ApiClient.scala
+++ b/src/main/scala/com/particeep/api/core/ApiClient.scala
@@ -6,6 +6,7 @@ import akka.actor.ActorSystem
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.ByteString
+import com.particeep.api.models.document.DocumentDownload
 import com.particeep.api.models.{ Error, ErrorResult, Errors }
 import play.api.libs.ws._
 import play.api.libs.json.{ Format, JsValue, Json }
@@ -16,7 +17,6 @@ import play.shaded.ahc.org.asynchttpclient.request.body.multipart.{ FilePart, Pa
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Random
 import scala.util.control.NonFatal
-import play.api.mvc.Result
 
 case class ApiCredential(apiKey: String, apiSecret: String, http_headers: Option[Seq[(String, String)]] = None) {
   def withHeader(name: String, value: String): ApiCredential = {
@@ -79,9 +79,10 @@ trait WSClient {
   )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, Source[ByteString, NotUsed]]]
 
   def getDoc(
-    path:    String,
-    timeOut: Long
-  )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, Result]]
+    document_id: String,
+    path:        String,
+    timeOut:     Long
+  )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, DocumentDownload]]
 
   def postStream(
     path:    String,
@@ -204,11 +205,12 @@ class ApiClient(
   }
 
   def getDoc(
-    path:    String,
-    timeOut: Long
-  )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, Result]] = {
-    parseDocumentStream(url(path, timeOut)).recover {
-      case NonFatal(e) => handle_error[Result](e, "GET", path)
+    document_id: String,
+    path:        String,
+    timeOut:     Long
+  )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, DocumentDownload]] = {
+    parseDocumentStream(document_id, url(path, timeOut)).recover {
+      case NonFatal(e) => handle_error[DocumentDownload](e, "GET", path)
     }
   }
 

--- a/src/main/scala/com/particeep/api/core/ResponseParser.scala
+++ b/src/main/scala/com/particeep/api/core/ResponseParser.scala
@@ -91,7 +91,7 @@ trait ResponseParser {
     )
   }
 
-  def validateStandardError(json: JsValue): Option[ErrorResult] = {
+  private[core] def validateStandardError(json: JsValue): Option[ErrorResult] = {
     json.validate[Errors] match {
       case result: JsSuccess[Errors] => Some(result.get)
       case _: JsError                => validateParsingError(json)

--- a/src/main/scala/com/particeep/api/models/document/DocumentDownload.scala
+++ b/src/main/scala/com/particeep/api/models/document/DocumentDownload.scala
@@ -1,0 +1,25 @@
+package com.particeep.api.models.document
+
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
+import play.api.http.HeaderNames
+
+case class DocumentDownload(
+    id:      String,
+    body:    Source[ByteString, _],
+    headers: Map[String, scala.collection.Seq[String]]
+) {
+  lazy val content_type: String =
+    headers
+      .get(HeaderNames.CONTENT_TYPE)
+      .flatMap(_.headOption)
+      .getOrElse("application/octet-stream")
+
+  lazy val content_length: Option[Long] =
+    headers
+      .get(HeaderNames.CONTENT_LENGTH) match {
+        case Some(Seq(length)) => length.toLongOption
+        case _                 => None
+      }
+  def getHeader(name: String): Option[String] = headers.get(name).flatMap(_.headOption)
+}


### PR DESCRIPTION
L'idée est de télécharger un document via l'API en utilisant le SDK.
Le SDK transforme la réponse HTTP en une classe Scala pour être manipulée par NGLE et SETUP afin qu'ils puissent forcer le téléchargement dans le navigateur.