### PR TITLE
renommer "url" en "document_id" pour DocumentGenerationAndUpload et DocumentGeneration

### DIFF
--- a/src/main/scala/com/particeep/api/models/document_generation/DocumentGeneration.scala
+++ b/src/main/scala/com/particeep/api/models/document_generation/DocumentGeneration.scala
@@ -3,9 +3,9 @@ package com.particeep.api.models.document_generation
 import play.api.libs.json.{ JsValue, Json }
 
 case class DocumentGeneration(
-    url:        String,
-    params_obj: Option[Map[String, JsValue]],
-    params_str: Option[Map[String, String]]
+    document_id: String,
+    params_obj:  Option[Map[String, JsValue]],
+    params_str:  Option[Map[String, String]]
 )
 
 object DocumentGeneration {

--- a/src/main/scala/com/particeep/api/models/document_generation/DocumentGenerationAndUpload.scala
+++ b/src/main/scala/com/particeep/api/models/document_generation/DocumentGenerationAndUpload.scala
@@ -3,7 +3,7 @@ package com.particeep.api.models.document_generation
 import play.api.libs.json.{ JsValue, Json }
 
 case class DocumentGenerationAndUpload(
-    url:                    String,
+    document_id:            String,
     params_obj:             Option[Map[String, JsValue]] = None,
     params_str:             Option[Map[String, String]]  = None,
     name:                   Option[String]               = None,


### PR DESCRIPTION
L'idée est qu'on ne passe plus l'url de téléchargement à particeep API mais l'id du document. C'est API qui se chargera de construire l'URL.