### PR TITLE
[Phase 13] On doit pouvoir consulter des documents publics sans être connecté

### DIFF
--- a/src/main/scala/com/particeep/api/DocumentClient.scala
+++ b/src/main/scala/com/particeep/api/DocumentClient.scala
@@ -57,11 +57,7 @@ class DocumentClient(val ws: WSClient, val credentials: Option[ApiCredential] = 
   }
 
   def download(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, DocumentDownload]] = {
-    ws.getDoc(document_id = id, path = s"$endPoint/download/$id", timeOut = timeout)
-  }
-
-  def downloadFree(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, DocumentDownload]] = {
-    ws.getDocFree(id, timeOut = timeout)
+    ws.getDoc(id, timeOut = timeout)
   }
 
   def byId(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, Document]] = {

--- a/src/main/scala/com/particeep/api/DocumentClient.scala
+++ b/src/main/scala/com/particeep/api/DocumentClient.scala
@@ -60,6 +60,10 @@ class DocumentClient(val ws: WSClient, val credentials: Option[ApiCredential] = 
     ws.getDoc(document_id = id, path = s"$endPoint/download/$id", timeOut = timeout)
   }
 
+  def downloadFree(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, DocumentDownload]] = {
+    ws.getDocFree(id, timeOut = timeout)
+  }
+
   def byId(id: String, timeout: Long = defaultTimeOut)(implicit exec: ExecutionContext): Future[Either[ErrorResult, Document]] = {
     ws.get[Document](s"$endPoint/$id", timeout)
   }

--- a/src/main/scala/com/particeep/api/core/ApiClient.scala
+++ b/src/main/scala/com/particeep/api/core/ApiClient.scala
@@ -86,7 +86,7 @@ trait WSClient {
   def getDoc(
     document_id: String,
     timeOut:     Long
-  )(implicit exec: ExecutionContext): Future[Either[ErrorResult, DocumentDownload]]
+  )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, DocumentDownload]]
 
   def postStream(
     path:    String,

--- a/src/main/scala/com/particeep/api/core/ApiClient.scala
+++ b/src/main/scala/com/particeep/api/core/ApiClient.scala
@@ -216,10 +216,11 @@ class ApiClient(
   def getDoc(
     document_id: String,
     timeOut:     Long
-  )(implicit exec: ExecutionContext): Future[Either[ErrorResult, DocumentDownload]] = {
+  )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, DocumentDownload]] = {
     val path = s"$baseUrl/document/$document_id"
-    sslClient
-      .url(path)
+
+    secure(sslClient.url(path), credentials, timeOut)
+      .addHttpHeaders(credentials.http_headers.getOrElse(List()): _*)
       .withRequestTimeout(timeOut millis)
       .withMethod(method = "GET")
       .execute()

--- a/src/main/scala/com/particeep/api/core/ApiClient.scala
+++ b/src/main/scala/com/particeep/api/core/ApiClient.scala
@@ -223,7 +223,7 @@ class ApiClient(
       .addHttpHeaders(credentials.http_headers.getOrElse(List()): _*)
       .withRequestTimeout(timeOut millis)
       .withMethod(method = "GET")
-      .execute()
+      .stream()
       .map(handleResponseForGetDoc(_, document_id))
       .recover {
         case NonFatal(e) => handle_error[DocumentDownload](e, method = "GET", path)

--- a/src/main/scala/com/particeep/api/core/ApiClient.scala
+++ b/src/main/scala/com/particeep/api/core/ApiClient.scala
@@ -23,6 +23,7 @@ import play.api.libs.json._
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+
 case class ApiCredential(apiKey: String, apiSecret: String, http_headers: Option[Seq[(String, String)]] = None) {
   def withHeader(name: String, value: String): ApiCredential = {
     val new_value = (name, value) :: this.http_headers.map(_.toList).getOrElse(List())

--- a/src/main/scala/com/particeep/api/core/ApiClient.scala
+++ b/src/main/scala/com/particeep/api/core/ApiClient.scala
@@ -85,12 +85,6 @@ trait WSClient {
 
   def getDoc(
     document_id: String,
-    path:        String,
-    timeOut:     Long
-  )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, DocumentDownload]]
-
-  def getDocFree(
-    document_id: String,
     timeOut:     Long
   )(implicit exec: ExecutionContext): Future[Either[ErrorResult, DocumentDownload]]
 
@@ -220,20 +214,6 @@ class ApiClient(
   }
 
   def getDoc(
-    document_id: String,
-    path:        String,
-    timeOut:     Long
-  )(implicit exec: ExecutionContext, credentials: ApiCredential): Future[Either[ErrorResult, DocumentDownload]] = {
-    url(path, timeOut)
-      .withMethod(method = "GET")
-      .execute()
-      .map(handleResponseForGetDoc(_, document_id))
-      .recover {
-        case NonFatal(e) => handle_error[DocumentDownload](e, method = "GET", path)
-      }
-  }
-
-  def getDocFree(
     document_id: String,
     timeOut:     Long
   )(implicit exec: ExecutionContext): Future[Either[ErrorResult, DocumentDownload]] = {


### PR DESCRIPTION
On n'utilise plus la route de téléchargement de l'API qui oblige à avoir un consumer valide.
On utilise la route de téléchargement de l'API qui accepte les connexions sans **forcément** un consumer existant.