### PR TITLE
feat(FundraiseEquity): add modification_form_id and cancellation_form

### DIFF
--- a/src/main/scala/com/particeep/api/models/fundraise/equity/FundraiseEquity.scala
+++ b/src/main/scala/com/particeep/api/models/fundraise/equity/FundraiseEquity.scala
@@ -39,6 +39,8 @@ case class FundraiseEquity(
   required_pro:          Option[Boolean]             = None,
   is_featured:           Option[Boolean]             = None,
   form_id:               Option[String]              = None,
+  modification_form_id:  Option[String]              = None,
+  cancellation_form_id:  Option[String]              = None,
   unicia_id:             Option[String]              = None,
   dismemberment_table:   Option[Map[String, String]] = None,
   offer:                 EquityOffer                 = EquityOffer()

--- a/src/main/scala/com/particeep/api/models/fundraise/equity/FundraiseEquityEdition.scala
+++ b/src/main/scala/com/particeep/api/models/fundraise/equity/FundraiseEquityEdition.scala
@@ -32,6 +32,8 @@ case class FundraiseEquityEdition(
   required_pro:          Option[Boolean]             = None,
   is_featured:           Option[Boolean]             = None,
   form_id:               Option[String]              = None,
+  modification_form_id:  Option[String]              = None,
+  cancellation_form_id:  Option[String]              = None,
   unicia_id:             Option[String]              = None,
   dismemberment_table:   Option[Map[String, String]] = None,
   offer:                 Option[EquityOffer]         = None

--- a/src/main/scala/com/particeep/api/models/fundraise/equity/FundraiseEquityRunningEdition.scala
+++ b/src/main/scala/com/particeep/api/models/fundraise/equity/FundraiseEquityRunningEdition.scala
@@ -21,6 +21,8 @@ case class FundraiseEquityRunningEdition(
   amount_target_max:     Option[Long]               = None,
   score:                 Option[String]             = None,
   form_id:               Option[String]             = None,
+  modification_form_id:  Option[String]             = None,
+  cancellation_form_id:  Option[String]             = None,
   unicia_id:             Option[String]             = None,
   tag:                   Option[String]             = None,
   is_featured:           Option[Boolean]            = None,


### PR DESCRIPTION
Add modification_form_id and cancellation_form_id SDK

[Ticket](https://app.shortcut.com/particeep/story/66077/back-configurer-un-formulaire-custom-diff%C3%A9rent-pour-chaque-situation)